### PR TITLE
Add wrapper function for BERT tokenization

### DIFF
--- a/text_extensions_for_pandas/io/__init__.py
+++ b/text_extensions_for_pandas/io/__init__.py
@@ -22,3 +22,4 @@
 from text_extensions_for_pandas.io.conll import *
 from text_extensions_for_pandas.io.spacy import *
 from text_extensions_for_pandas.io.systemt import *
+from text_extensions_for_pandas.io.tokenization import *

--- a/text_extensions_for_pandas/io/test_tokenization.py
+++ b/text_extensions_for_pandas/io/test_tokenization.py
@@ -1,0 +1,78 @@
+#
+#  Copyright (c) 2020 IBM Corp.
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import unittest
+
+import pandas as pd
+from transformers import BertTokenizerFast
+
+from text_extensions_for_pandas.io.tokenization import make_bert_tokens
+
+
+class TestTokenize(unittest.TestCase):
+
+    def setUp(self):
+        # Ensure that diffs are consistent
+        pd.set_option("display.max_columns", 250)
+
+    def tearDown(self):
+        pd.reset_option("display.max_columns")
+
+    def test_make_bert_tokens(self):
+        text = "the quick brown fox jumps over the lazy dog."
+        tokenizer = BertTokenizerFast.from_pretrained('bert-base-uncased', add_special_tokens=True)
+        bert_toks = make_bert_tokens(text, tokenizer)
+
+        self.assertIsInstance(bert_toks, pd.DataFrame)
+        self.assertEqual(len(bert_toks.columns), 7)
+
+        # verify input id is correct
+        self.assertTrue('input_id' in bert_toks.columns)
+        input_id = bert_toks['input_id']
+        self.assertEqual(input_id.iloc[0], 101)  # docstart
+        self.assertEqual(input_id.iloc[len(input_id) - 1], 102)  # docend
+        self.assertEqual(len(set(input_id)), len(input_id) - 1)  # token "the" appears twice
+
+        # verify special tokens mask
+        self.assertTrue('special_tokens_mask' in bert_toks.columns)
+        special_tokens_mask = bert_toks['special_tokens_mask']
+        self.assertEqual(special_tokens_mask.iloc[0], True)
+        self.assertTrue(not any(special_tokens_mask.iloc[1:-1]))
+        self.assertEqual(special_tokens_mask.iloc[len(special_tokens_mask) - 1], True)
+
+        # verify char span array
+        self.assertTrue('char_span' in bert_toks.columns)
+        char_span = bert_toks['char_span']
+        span = char_span.iloc[0]
+        self.assertEqual(span.begin, span.end)  # docstart special token
+        span = char_span.iloc[len(char_span) - 1]
+        self.assertEqual(span.begin, span.end)  # docend special token
+        expected = text[:-1].split() + [text[-1]]  # remove then append period
+        tokens = [span.covered_text for span in char_span]
+        for e in expected:
+            self.assertTrue(e in tokens)
+
+        # verify token span array
+        self.assertTrue('token_span' in bert_toks.columns)
+        token_span = bert_toks['token_span']
+        span = token_span.iloc[0]
+        self.assertEqual(span.begin, span.end)  # docstart special token
+        span = token_span.iloc[len(token_span) - 1]
+        self.assertEqual(span.begin, span.end)  # docend special token
+
+        # verify token spans match char spans
+        char_span_text = [s.covered_text for s in char_span]
+        token_span_text = [s.covered_text for s in token_span]
+        self.assertListEqual(char_span_text, token_span_text)

--- a/text_extensions_for_pandas/io/tokenization.py
+++ b/text_extensions_for_pandas/io/tokenization.py
@@ -1,0 +1,97 @@
+#
+#  Copyright (c) 2020 IBM Corp.
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+################################################################################
+# tokenize.py
+#
+# Functions for tokenization of text
+
+import numpy as np
+import pandas as pd
+
+from text_extensions_for_pandas.array import (
+    CharSpanArray,
+    TokenSpanArray,
+)
+
+
+def make_bert_tokens(target_text: str, tokenizer) -> pd.DataFrame:
+    """
+    Tokenize the indicated text for BERT embeddings and return a DataFrame
+    with one row per token.
+
+    :param: target_text: string to tokenize
+    :param: tokenizer: A tokenizer that is a subclass of huggingface transformers
+                       PreTrainingTokenizerFast which supports `encode_plus` with
+                       return_offsets_mapping=True.
+
+    :returns: A `pd.DataFrame` with the following columns:
+     * "id": unique integer ID for each token
+     * "char_span": span of the token with character offsets
+     * "token_span": span of the token with token offsets
+     * "input_id": integer ID suitable for input to a BERT embedding model
+     * "token_type_id": list of token type ids to be fed to a model
+     * "attention_mask": list of indices specifying which tokens should be
+                         attended to by the model
+     * "special_tokens_mask": `True` if the token is a zero-length special token
+       such as "start of document"
+    """
+    from transformers.tokenization_utils import PreTrainedTokenizerFast
+    if not isinstance(tokenizer, PreTrainedTokenizerFast):
+        raise TypeError("Tokenizer must be an instance of "
+                        "transformers.PreTrainedTokenizerFast that supports "
+                        "encode_plus with return_offsets_mapping=True.")
+    tokenized_result = tokenizer.encode_plus(target_text,
+                                             return_special_tokens_mask=True,
+                                             return_offsets_mapping=True)
+
+    # Get offset mapping from tokenizer
+    offsets = tokenized_result["offset_mapping"]
+
+    # Init any special tokens at beginning
+    i = 0
+    while offsets[i] is None:
+        offsets[i] = (0, 0)
+        i += 1
+
+    # Make a DataFrame to unzip (begin, end) offsets
+    offset_df = pd.DataFrame(offsets, columns=["begin", "end"])
+
+    # Convert special tokens mask to boolean
+    special_tokens_mask = \
+        pd.Series(tokenized_result["special_tokens_mask"]).astype('bool')
+
+    # Fill remaining special tokens to zero-length spans
+    ends = offset_df['end'].fillna(method='ffill').astype('int32')
+    begins = offset_df['begin'].mask(special_tokens_mask, other=ends).astype('int32')
+
+    # Create char and token span arrays
+    char_spans = CharSpanArray(target_text, begins, ends)
+    token_spans = TokenSpanArray(char_spans,
+                                 np.arange(len(char_spans)),
+                                 np.arange(1, len(char_spans) + 1))
+
+    token_features = pd.DataFrame({
+        "id": special_tokens_mask.index,
+        # Use values instead of series because different indexes
+        "char_span": pd.Series(char_spans).values,
+        "token_span": pd.Series(token_spans).values,
+        "input_id": tokenized_result["input_ids"],
+        "token_type_id": tokenized_result["token_type_ids"],
+        "attention_mask": tokenized_result["attention_mask"],
+        "special_tokens_mask": special_tokens_mask,
+    })
+
+    return token_features


### PR DESCRIPTION
Add function `make_bert_tokens` to wrap a huggingface `PreTrainedTokenizerFast` tokenizer and return result as a Pandas DataFrame that includes all data from the tokenizer with character span, and token span columns.