### PR TITLE
Change IOB references to indicate IOB2 format

### DIFF
--- a/notebooks/CoNLL_1.ipynb
+++ b/notebooks/CoNLL_1.ipynb
@@ -587,7 +587,7 @@
     }
    ],
    "source": [
-    "# Convert the gold standard to spans.\n",
+    "# Convert the gold standard to spans, using IOB2 format. See https://en.wikipedia.org/wiki/Inside%E2%80%93outside%E2%80%93beginning_(tagging) for IOB2 details.\n",
     "# Again, one dataframe per document.\n",
     "gold_standard_spans = [tp.iob_to_spans(df) for df in gold_standard]\n",
     "bender_output_spans = [tp.iob_to_spans(df) for df in bender_output]\n",

--- a/notebooks/CoNLL_2.ipynb
+++ b/notebooks/CoNLL_2.ipynb
@@ -347,7 +347,8 @@
     }
    ],
    "source": [
-    "# Convert results from IOB tags to spans across all teams and documents\n",
+    "# Convert results from IOB2 tags to spans across all teams and documents\n",
+    "# See https://en.wikipedia.org/wiki/Inside%E2%80%93outside%E2%80%93beginning_(tagging) for details on IOB2 format.\n",
     "output_spans = {\n",
     "    t: [tp.iob_to_spans(df) for df in outputs[t]] for t in teams\n",
     "}  # Type: Dict[str, List[pd.DataFrame]]\n",

--- a/notebooks/CoNLL_3.ipynb
+++ b/notebooks/CoNLL_3.ipynb
@@ -171,7 +171,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Align the BERT tokens with the original tokenization and regenarate the IOB tags\n",
+    "# Align the BERT tokens with the original tokenization and regenarate the IOB2 tags.\n",
+    "# See https://en.wikipedia.org/wiki/Inside%E2%80%93outside%E2%80%93beginning_(tagging)\n",
     "# Start by converting the elements of gold_standard_spans to character spans\n",
     "new_gold_standard_spans = []\n",
     "for i in range(len(gold_standard_spans)):\n",
@@ -207,10 +208,10 @@
    "outputs": [],
    "source": [
     "# TODO: \n",
-    "# * Move the functions above into text_extensions_for_pandas package\n",
-    "# * Add regression tests of the new functions\n",
+    "# X Move the functions above into text_extensions_for_pandas package\n",
+    "# X Add regression tests of the new functions\n",
     "# * Add regression test of align_to_tokens\n",
-    "# * Implement the inverse of iob_to_spans(), say, \"spans_to_iob\"\n",
+    "# X Implement the inverse of iob_to_spans(), say, \"spans_to_iob\"\n",
     "# * In this notebook, use spans_to_iob() to add columns \"ent_iob\" and \"ent_type\"\n",
     "#   to the BERT tokens dataframe for each document\n",
     "# * Also in this notebook, align the sentences on BERT tokens and add a \n",


### PR DESCRIPTION
The IOB2 format is what is being used, change references to indicate that along with links to wikipedia entry https://en.wikipedia.org/wiki/Inside%E2%80%93outside%E2%80%93beginning_(tagging).